### PR TITLE
Add support to specify the number of threads to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,11 @@ Compression example:
 ```python
 import zipfile_zstd as zipfile
 
-zf = zipfile.ZipFile('/tmp/test.zip', 'w', zipfile.ZIP_ZSTANDARD, compresslevel=19)
+zf = zipfile.ZipFile('/tmp/test.zip', 'w', zipfile.ZIP_ZSTANDARD, compresslevel=19, threads = -1)
 zf.write('large_file.img')
 ```
 
-Dictionaries and advanced compression parameters are not supported, sorry.
+Set `threads=-1` to automatically detect and use all available logical cores, or set the number of desired threads.
+The default is to use **half** of the available logical threads/cores.
 
+Dictionaries and other advanced compression parameters are not yet supported.

--- a/zipfile_zstd/__init__.py
+++ b/zipfile_zstd/__init__.py
@@ -6,5 +6,6 @@ from zipfile import *
 from zipfile import (
     ZIP_ZSTANDARD,
     ZSTANDARD_VERSION,
+    ZSTANDARD_THREADS
 )
 


### PR DESCRIPTION
Patch zipfile.ZipFile() to add a `threads` parameter specifying the number of threads to use.
Default is to use half of the available threads; set to -1 to use all available threads, or set the number of threads to use. 